### PR TITLE
doc: binary must be in './lib/bashunit'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ It requires [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter
 Plug 'rcasia/neotest-bash'
 ```
 
+> **NOTE**: this plugin expects the `bashunit` binary to be in `./lib/bashunit`.
+
 ## ⚙ Configuration
 ```lua
 require("neotest").setup({


### PR DESCRIPTION
Highlighting in the README that bashunit binary must be in `./lib/bashunit`.

(this is kinda related with #14)