### PR TITLE
Add `args` option to adapter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,36 @@ require("neotest").setup({
       -- If not provided, the path will be inferred by checking for
       -- lib/bashunit in your repo root/cwd, or for bashunit on the $PATH
       executable = "path/to/bashunit/executable",
+      -- Additional CLI arguments passed to bashunit on every run.
+      -- Useful for enabling coverage or other flags.
+      args = {},
     })
   }
 })
 ```
+
+### Passing extra arguments
+
+Use the `args` option to pass additional CLI flags to bashunit. For example, to enable coverage reporting:
+
+```lua
+require("neotest").setup({
+  adapters = {
+    require("neotest-bash")({
+      args = {
+        "--coverage",
+        "--coverage-paths", "bin",
+        "--coverage-report", vim.fn.getcwd() .. "/coverage/lcov.info",
+      },
+    })
+  }
+})
+```
+
+You can also pass one-off arguments via neotest's `extra_args` when running tests:
+
+```lua
+require("neotest").run.run({ extra_args = { "--report-coverage" } })
+```
+
+Arguments from both `args` (config) and `extra_args` (per-run) are merged together.

--- a/lua/neotest-bash/core/spec_builder.lua
+++ b/lua/neotest-bash/core/spec_builder.lua
@@ -17,6 +17,10 @@ SpecBuilder = {
 			error("bashunit not found")
 		end
 
+		local config_args = (config and config.args) or {}
+		local extra_args = args.extra_args or {}
+		local all_args = vim.list_extend(vim.list_extend({}, config_args), extra_args)
+
 		local commands = {}
 		for _, node in tree:iter_nodes() do
 			local node_data = node:data()
@@ -27,6 +31,7 @@ SpecBuilder = {
 				command:filter(symbol)
 				command:executable(bashunit_path)
 				command:path(path)
+				command:args(all_args)
 
 				-- add command to list of commands
 				commands[#commands + 1] = {

--- a/lua/neotest-bash/init.lua
+++ b/lua/neotest-bash/init.lua
@@ -65,8 +65,10 @@ end
 
 ---@class neotest-bash.AdapterConfig
 ---@field executable? string
+---@field args? string[]
 local defaults = {
 	executable = "lib/bashunit",
+	args = {},
 }
 
 local M = create_adapter(defaults)

--- a/lua/neotest-bash/util/command_builder.lua
+++ b/lua/neotest-bash/util/command_builder.lua
@@ -2,6 +2,7 @@ local CommandBuilder = {
 	_executable = "",
 	_path = "",
 	_filter = "",
+	_args = {},
 
 	--- @return CommandBuilder
 	new = function(self)
@@ -29,12 +30,22 @@ local CommandBuilder = {
 		return self
 	end,
 
+	---@param args string[] @additional CLI arguments
+	args = function(self, args)
+		self._args = args
+		return self
+	end,
+
 	--- @return string @command to run
 	build = function(self)
-		if self._filter == "" then
-			return self._executable .. " " .. self._path
+		local cmd = self._executable .. " " .. self._path
+		if self._filter ~= "" then
+			cmd = cmd .. " --filter " .. self._filter
 		end
-		return self._executable .. " " .. self._path .. " --filter " .. self._filter
+		if self._args and #self._args > 0 then
+			cmd = cmd .. " " .. table.concat(self._args, " ")
+		end
+		return cmd
 	end,
 }
 

--- a/tests/core/spec_builder_spec.lua
+++ b/tests/core/spec_builder_spec.lua
@@ -116,6 +116,103 @@ describe("spec_builder", function()
 		assert.are.same(expected_spec, result)
 	end)
 
+	async.it("should include config.args in command", function()
+		-- given
+		local path = "tests/fixtures/example_test.sh"
+		local tree = plugin.discover_positions(path)
+		local args = { tree = tree }
+		local mocked_root = "/home/user/mocked/directory/"
+		mock_root_finder(mocked_root)
+
+		local mocked_bashunit_path = "./lib/bashunit"
+		mock_bashunit_finder(mocked_bashunit_path)
+
+		local adapter = plugin({ args = { "--report-coverage" } })
+
+		-- when
+		local result = adapter.build_spec(args)
+
+		-- then
+		local expected_spec = {
+			{
+				command = "./lib/bashunit tests/fixtures/example_test.sh --filter test_sum_1_plus_1 --report-coverage",
+				cwd = mocked_root,
+				symbol = "test_sum_1_plus_1",
+			},
+			{
+				command = "./lib/bashunit tests/fixtures/example_test.sh --filter test_sum_2_plus_2 --report-coverage",
+				cwd = mocked_root,
+				symbol = "test_sum_2_plus_2",
+			},
+		}
+
+		assert.are.same(expected_spec, result)
+	end)
+
+	async.it("should include extra_args in command", function()
+		-- given
+		local path = "tests/fixtures/example_test.sh"
+		local tree = plugin.discover_positions(path)
+		local args = { tree = tree, extra_args = { "--verbose" } }
+		local mocked_root = "/home/user/mocked/directory/"
+		mock_root_finder(mocked_root)
+
+		local mocked_bashunit_path = "./lib/bashunit"
+		mock_bashunit_finder(mocked_bashunit_path)
+
+		-- when
+		local result = plugin.build_spec(args)
+
+		-- then
+		local expected_spec = {
+			{
+				command = "./lib/bashunit tests/fixtures/example_test.sh --filter test_sum_1_plus_1 --verbose",
+				cwd = mocked_root,
+				symbol = "test_sum_1_plus_1",
+			},
+			{
+				command = "./lib/bashunit tests/fixtures/example_test.sh --filter test_sum_2_plus_2 --verbose",
+				cwd = mocked_root,
+				symbol = "test_sum_2_plus_2",
+			},
+		}
+
+		assert.are.same(expected_spec, result)
+	end)
+
+	async.it("should merge config.args and extra_args", function()
+		-- given
+		local path = "tests/fixtures/example_test.sh"
+		local tree = plugin.discover_positions(path)
+		local args = { tree = tree, extra_args = { "--verbose" } }
+		local mocked_root = "/home/user/mocked/directory/"
+		mock_root_finder(mocked_root)
+
+		local mocked_bashunit_path = "./lib/bashunit"
+		mock_bashunit_finder(mocked_bashunit_path)
+
+		local adapter = plugin({ args = { "--report-coverage" } })
+
+		-- when
+		local result = adapter.build_spec(args)
+
+		-- then
+		local expected_spec = {
+			{
+				command = "./lib/bashunit tests/fixtures/example_test.sh --filter test_sum_1_plus_1 --report-coverage --verbose",
+				cwd = mocked_root,
+				symbol = "test_sum_1_plus_1",
+			},
+			{
+				command = "./lib/bashunit tests/fixtures/example_test.sh --filter test_sum_2_plus_2 --report-coverage --verbose",
+				cwd = mocked_root,
+				symbol = "test_sum_2_plus_2",
+			},
+		}
+
+		assert.are.same(expected_spec, result)
+	end)
+
 	async.it("should throw an error if bashunit executable cannot be found", function()
 		-- given
 		--

--- a/tests/util/command_builder_spec.lua
+++ b/tests/util/command_builder_spec.lua
@@ -1,0 +1,51 @@
+---@diagnostic disable: undefined-global
+local CommandBuilder = require("neotest-bash.util.command_builder")
+
+describe("command_builder", function()
+	describe("args", function()
+		it("should build command without args", function()
+			local cmd = CommandBuilder:new()
+			cmd:executable("./lib/bashunit")
+			cmd:path("test.sh")
+
+			assert.are.same("./lib/bashunit test.sh", cmd:build())
+		end)
+
+		it("should build command with empty args table", function()
+			local cmd = CommandBuilder:new()
+			cmd:executable("./lib/bashunit")
+			cmd:path("test.sh")
+			cmd:args({})
+
+			assert.are.same("./lib/bashunit test.sh", cmd:build())
+		end)
+
+		it("should build command with a single arg", function()
+			local cmd = CommandBuilder:new()
+			cmd:executable("./lib/bashunit")
+			cmd:path("test.sh")
+			cmd:args({ "--report-coverage" })
+
+			assert.are.same("./lib/bashunit test.sh --report-coverage", cmd:build())
+		end)
+
+		it("should build command with multiple args", function()
+			local cmd = CommandBuilder:new()
+			cmd:executable("./lib/bashunit")
+			cmd:path("test.sh")
+			cmd:args({ "--report-coverage", "--verbose" })
+
+			assert.are.same("./lib/bashunit test.sh --report-coverage --verbose", cmd:build())
+		end)
+
+		it("should build command with filter and args", function()
+			local cmd = CommandBuilder:new()
+			cmd:executable("./lib/bashunit")
+			cmd:path("test.sh")
+			cmd:filter("test_it_works")
+			cmd:args({ "--report-coverage" })
+
+			assert.are.same("./lib/bashunit test.sh --filter test_it_works --report-coverage", cmd:build())
+		end)
+	end)
+end)


### PR DESCRIPTION
Adds support for passing additional CLI arguments to bashunit through the adapter config and neotest extra_args.

### Changes
- Add `args` option to adapter config (e.g. `{ args = { "--report-coverage" } }`)
- Add `args()` method to `CommandBuilder` to append extra CLI flags
- Merge config args and neotest `extra_args` in `SpecBuilder`
- Add tests for `CommandBuilder` args handling and `SpecBuilder` args merging

### Example

This is what I ended up using to get my workflow working:

```lua
        require 'neotest-bash' {
          args = { '--coverage', '--coverage-paths', 'bin', '--coverage-report', vim.fn.getcwd() .. '/coverage/lcov.info' },
        },
```

Let me know if you have any questions or need any updates.